### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,6 @@ issues should not be filed there.
 [GPLv2+](http://www.gnu.org/licenses/gpl-2.0.html)
 
 [docs]: http://wp-api.org/
-[GitHub]: https://github.com/WP-API/WP-API
+[GitHub]: https://github.com/WP-API/WP-API/issues
 [GSOC Trac]: https://gsoc.trac.wordpress.org/query?component=JSON+REST+API
-[recent updates]: http://make.wordpress.org/core/tag/json-api/
+[recent updates]: https://make.wordpress.org/core/tag/json-api/


### PR DESCRIPTION
Improve readme - update url to correct github ticket link and fix make.wordpress.org link (https)
